### PR TITLE
v0.4.2 - changed directory folder for the aliquot menu

### DIFF
--- a/src/org/cirdles/chroni/AliquotMenuActivity.java
+++ b/src/org/cirdles/chroni/AliquotMenuActivity.java
@@ -91,8 +91,8 @@ public class AliquotMenuActivity extends Activity {
                 Toast.makeText(AliquotMenuActivity.this, "Opening table...", Toast.LENGTH_LONG).show(); // lets user know table is opening
                 Intent openMainMenu = new Intent("android.intent.action.DISPLAY"); // Opens display table
                 openMainMenu.putExtra("AliquotXML", getIntent().getStringExtra("AliquotXMLFileName")); // Sends selected aliquot file name for display
-                aliquotFileSubmitButton.setBackgroundColor(Color.GREEN);
-                aliquotFileSubmitButton.setTextColor(Color.BLACK);
+                aliquotFileSubmitButton.setBackgroundColor(Color.rgb(242, 136, 58)); // changes color to cirdles orange
+                aliquotFileSubmitButton.setTextColor(Color.WHITE);
                 startActivity(openMainMenu);
             }else{
                 // Tells user to select a file for viewing

--- a/src/org/cirdles/chroni/AliquotMenuActivity.java
+++ b/src/org/cirdles/chroni/AliquotMenuActivity.java
@@ -2,19 +2,16 @@
 
 package org.cirdles.chroni;
 
-import java.io.File;
-import android.app.AlertDialog;
-import android.content.DialogInterface;
-import android.graphics.Color;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-import android.net.Uri;
-import android.os.Bundle;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
+import android.graphics.Color;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.net.Uri;
+import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -22,6 +19,9 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.RelativeLayout;
 import android.widget.Toast;
+
+import java.io.File;
+
 
 public class AliquotMenuActivity extends Activity {
 
@@ -45,6 +45,8 @@ public class AliquotMenuActivity extends Activity {
     public static String BASE_SAMPLE_URI = "http://www.geosamples.org/display.php?igsn=";
 
     private static final int REQUEST_PICK_FILE = 1;
+    public int CIRDLES_ORANGE_RGB = Color.rgb(242, 136, 58);
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -91,7 +93,7 @@ public class AliquotMenuActivity extends Activity {
                 Toast.makeText(AliquotMenuActivity.this, "Opening table...", Toast.LENGTH_LONG).show(); // lets user know table is opening
                 Intent openMainMenu = new Intent("android.intent.action.DISPLAY"); // Opens display table
                 openMainMenu.putExtra("AliquotXML", getIntent().getStringExtra("AliquotXMLFileName")); // Sends selected aliquot file name for display
-                aliquotFileSubmitButton.setBackgroundColor(Color.rgb(242, 136, 58)); // changes color to cirdles orange
+                aliquotFileSubmitButton.setBackgroundColor(CIRDLES_ORANGE_RGB); // changes color to cirdles orange
                 aliquotFileSubmitButton.setTextColor(Color.WHITE);
                 startActivity(openMainMenu);
             }else{
@@ -124,6 +126,7 @@ public class AliquotMenuActivity extends Activity {
 
                     String aliquotIGSN = igsnText.getText().toString().toUpperCase().trim(); // Captures igsn from user input
                     URLFileReader downloader = new URLFileReader(AliquotMenuActivity.this, "AliquotMenu", makeURI(BASE_ALIQUOT_URI, aliquotIGSN), "igsn"); // Downloads Aliquot file
+                    igsnDownloadButton.setBackgroundColor(CIRDLES_ORANGE_RGB);
 
                     // Note: Setting above is useful for download-then-open functionality
                 }
@@ -133,6 +136,8 @@ public class AliquotMenuActivity extends Activity {
         }
 
     });
+
+
 
     }
 

--- a/src/org/cirdles/chroni/FilePickerActivity.java
+++ b/src/org/cirdles/chroni/FilePickerActivity.java
@@ -85,16 +85,6 @@ public class FilePickerActivity extends ListActivity {
 
         //Sets the initial directory based on what file user is looking for (Aliquot or Report Settings)
 		if(getIntent().hasExtra("Default_Directory")){
-            /**
-			if(getIntent().getStringExtra("Default_Directory").contentEquals("Aliquot_CHRONI_Directory")){
-                mainDirectory = new File(Environment.getExternalStorageDirectory() + "/CHRONI/Aliquot"); // Takes user to Aliquot CHRONI Folder
-			}else if(getIntent().getStringExtra("Default_Directory").contentEquals("Report_Settings_CHRONI_Directory")) {
-                mainDirectory = new File(Environment.getExternalStorageDirectory() + "/CHRONI/Report Settings"); // Takes user to Report Settings CHRONI Folder
-            }else if(getIntent().getStringExtra("Default_Directory").contentEquals("Aliquot_Directory")||getIntent().getStringExtra("Default_Directory").contentEquals("Report_Settings_Directory")){
-				mainDirectory = Environment.getExternalStorageDirectory(); // Takes user to root directory folder
-            }
-             **/
-
             if (getIntent().getStringExtra("Default_Directory").contentEquals("Aliquot_Directory")||getIntent().getStringExtra("Default_Directory").contentEquals("Report_Settings_Directory"))
             {
                 mainDirectory = new File(Environment.getExternalStorageDirectory() + "/CHRONI/Aliquot"); // Takes user to the Aliquot folder

--- a/src/org/cirdles/chroni/FilePickerActivity.java
+++ b/src/org/cirdles/chroni/FilePickerActivity.java
@@ -85,6 +85,7 @@ public class FilePickerActivity extends ListActivity {
 
         //Sets the initial directory based on what file user is looking for (Aliquot or Report Settings)
 		if(getIntent().hasExtra("Default_Directory")){
+            /**
 			if(getIntent().getStringExtra("Default_Directory").contentEquals("Aliquot_CHRONI_Directory")){
                 mainDirectory = new File(Environment.getExternalStorageDirectory() + "/CHRONI/Aliquot"); // Takes user to Aliquot CHRONI Folder
 			}else if(getIntent().getStringExtra("Default_Directory").contentEquals("Report_Settings_CHRONI_Directory")) {
@@ -92,7 +93,16 @@ public class FilePickerActivity extends ListActivity {
             }else if(getIntent().getStringExtra("Default_Directory").contentEquals("Aliquot_Directory")||getIntent().getStringExtra("Default_Directory").contentEquals("Report_Settings_Directory")){
 				mainDirectory = Environment.getExternalStorageDirectory(); // Takes user to root directory folder
             }
-		}
+             **/
+
+            if (getIntent().getStringExtra("Default_Directory").contentEquals("Aliquot_Directory")||getIntent().getStringExtra("Default_Directory").contentEquals("Report_Settings_Directory"))
+            {
+                mainDirectory = new File(Environment.getExternalStorageDirectory() + "/CHRONI/Aliquot"); // Takes user to the Aliquot folder
+		    }else if(getIntent().getStringExtra("Default_Directory").contentEquals("Report_Settings_CHRONI_Directory")) {
+                mainDirectory = new File(Environment.getExternalStorageDirectory() + "CHRONI/Report Settings");
+            }
+
+        }
 		
 		// Initialize the ArrayList
 		mFiles = new ArrayList<File>();

--- a/src/org/cirdles/chroni/UserProfileActivity.java
+++ b/src/org/cirdles/chroni/UserProfileActivity.java
@@ -19,6 +19,7 @@ import org.xml.sax.SAXException;
 import com.loopj.android.http.AsyncHttpResponseHandler;
 import com.loopj.android.http.RequestParams;
 
+import android.graphics.Color;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
@@ -50,6 +51,8 @@ public class UserProfileActivity extends Activity {
 
 	public static final String USER_REGISTERED = "My CIRDLES Application";
     public static final String USER_PREFS = "My CIRDLES Settings";
+
+    public int CIRDLES_ORANGE_RGB = Color.rgb(242, 136, 58);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -90,6 +93,10 @@ public class UserProfileActivity extends Activity {
                 editor.putString("Geochron Password", geochronPasswordInput
                         .getText().toString());
                 editor.commit();
+
+                profileValidateButton.setBackgroundColor(CIRDLES_ORANGE_RGB); // changes color to cirdles orange
+
+
 
                 // Provides feedback that credentials have been saved
                 Toast.makeText(UserProfileActivity.this, "Your Geochron Profile information is saved!", Toast.LENGTH_SHORT).show();
@@ -136,18 +143,19 @@ public class UserProfileActivity extends Activity {
 	profileEraseButton = (Button) findViewById(R.id.profileEraseButton);
 	profileEraseButton.setOnClickListener(new View.OnClickListener() {
 	    public void onClick(View v) {
-	    	if(geochronUsernameInput.getText().length() != 0 || geochronPasswordInput.getText().length() != 0){
+	    	if(geochronUsernameInput.getText().length() != 0 || geochronPasswordInput.getText().length() != 0) {
 
-			SharedPreferences settings = getSharedPreferences(USER_PREFS, 0);
-			SharedPreferences.Editor editor = settings.edit();
-			editor.clear(); // Clears previously stored prefs
-			
-			geochronUsernameInput.setText("");
-			geochronPasswordInput.setText("");
-			
-    		Toast.makeText(UserProfileActivity.this, "Credentials erased!", Toast.LENGTH_LONG).show();
-	    	}
-	    }
+                SharedPreferences settings = getSharedPreferences(USER_PREFS, 0);
+                SharedPreferences.Editor editor = settings.edit();
+                editor.clear(); // Clears previously stored prefs
+
+                geochronUsernameInput.setText("");
+                geochronPasswordInput.setText("");
+
+                profileEraseButton.setBackgroundColor(CIRDLES_ORANGE_RGB);
+            }
+
+        }
 	 	});
 			
 	// Initializes profile information with currently stored profile or, if
@@ -176,7 +184,7 @@ public class UserProfileActivity extends Activity {
     
     /**
     * Validates currently stored geochron credentials 
-    * From U-Pb Redux's ReduxPersistantState.class
+    * From ET Redux's ReduxPersistantState.class
     * http://www.geochronportal.org/post_to_credentials_service.html
     * 
     * @param username


### PR DESCRIPTION
When in the aliquot menu, if you click on the plus button to add an aliquot file, the directory folder is CHRONI/Aliquot instead of the root menu. This makes sure users will not try to add a report settings file. 
"+" button --> aliquot files directory 
