### PR TITLE
Enabled container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: android
 
+# enables container-based infrastructure
+sudo: false
+
 android:
   components:
     - build-tools-20.0.0


### PR DESCRIPTION
Enabled the container-based infrastructure for Travis CI builds. See [Build #5](https://travis-ci.org/CIRDLES/CHRONI/builds/83147751) for the notice that we are currently on the legacy infrastructure. See [here](http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade) for the documentation on migrating.
