### PR TITLE
v0.8.2 - Help Menu Item Fix

### DIFF
--- a/src/main/java/org/cirdles/chroni/AboutActivity.java
+++ b/src/main/java/org/cirdles/chroni/AboutActivity.java
@@ -92,7 +92,7 @@ public class AboutActivity extends Activity  {
                 return true;
             case R.id.helpMenu: // Takes user to help blog
                 Intent openHelpBlog = new Intent(Intent.ACTION_VIEW,
-                        Uri.parse("http://chronihelpblog.wordpress.com"));
+                        Uri.parse(getString(R.string.chroni_help_address)));
                 startActivity(openHelpBlog);
                 return true;
             default:

--- a/src/main/java/org/cirdles/chroni/AliquotMenuActivity.java
+++ b/src/main/java/org/cirdles/chroni/AliquotMenuActivity.java
@@ -360,7 +360,7 @@ public class AliquotMenuActivity extends Activity {
                 return true;
             case R.id.helpMenu: // Takes user to help blog
                 Intent openHelpBlog = new Intent(Intent.ACTION_VIEW,
-                        Uri.parse("http://chronihelpblog.wordpress.com"));
+                        Uri.parse(getString(R.string.chroni_help_address)));
                 startActivity(openHelpBlog);
                 return true;
             default:

--- a/src/main/java/org/cirdles/chroni/FilePickerActivity.java
+++ b/src/main/java/org/cirdles/chroni/FilePickerActivity.java
@@ -332,7 +332,7 @@ public class FilePickerActivity extends ListActivity {
                 return true;
             case R.id.helpMenu: // Takes user to help blog
                 Intent openHelpBlog = new Intent(Intent.ACTION_VIEW,
-                        Uri.parse("http://chronihelpblog.wordpress.com"));
+                        Uri.parse(getString(R.string.chroni_help_address)));
                 startActivity(openHelpBlog);
                 return true;
             default:

--- a/src/main/java/org/cirdles/chroni/HistoryActivity.java
+++ b/src/main/java/org/cirdles/chroni/HistoryActivity.java
@@ -212,7 +212,7 @@ public class HistoryActivity extends Activity {
                 return true;
             case R.id.helpMenu: // Takes user to help blog
                 Intent openHelpBlog = new Intent(Intent.ACTION_VIEW,
-                        Uri.parse("http://chronihelpblog.wordpress.com"));
+                        Uri.parse(getString(R.string.chroni_help_address)));
                 startActivity(openHelpBlog);
                 return true;
             default:

--- a/src/main/java/org/cirdles/chroni/MainMenuActivity.java
+++ b/src/main/java/org/cirdles/chroni/MainMenuActivity.java
@@ -137,7 +137,7 @@ public class MainMenuActivity extends Activity {
                 return true;
             case R.id.helpMenu: // Takes user to help blog
                 Intent openHelpBlog = new Intent(Intent.ACTION_VIEW,
-                        Uri.parse("http://chronihelpblog.wordpress.com"));
+                        Uri.parse(getString(R.string.chroni_help_address)));
                 startActivity(openHelpBlog);
                 return true;
             default:

--- a/src/main/java/org/cirdles/chroni/ReportSettingsMenuActivity.java
+++ b/src/main/java/org/cirdles/chroni/ReportSettingsMenuActivity.java
@@ -277,7 +277,7 @@ Splits report settings file name returning a displayable version without the ent
                 return true;
             case R.id.helpMenu: // Takes user to help blog
                 Intent openHelpBlog = new Intent(Intent.ACTION_VIEW,
-                        Uri.parse("http://chronihelpblog.wordpress.com"));
+                        Uri.parse(getString(R.string.chroni_help_address)));
                 startActivity(openHelpBlog);
                 return true;
             default:

--- a/src/main/java/org/cirdles/chroni/TablePainterActivity.java
+++ b/src/main/java/org/cirdles/chroni/TablePainterActivity.java
@@ -806,7 +806,7 @@ Splits report settings file name returning a displayable version without the ent
                 return true;
             case R.id.helpMenu: // Takes user to help blog
                 Intent openHelpBlog = new Intent(Intent.ACTION_VIEW,
-                        Uri.parse("http://chronihelpblog.wordpress.com"));
+                        Uri.parse(getString(R.string.chroni_help_address)));
                 startActivity(openHelpBlog);
                 return true;
             default:

--- a/src/main/java/org/cirdles/chroni/UserProfileActivity.java
+++ b/src/main/java/org/cirdles/chroni/UserProfileActivity.java
@@ -394,7 +394,7 @@ public class UserProfileActivity extends Activity {
                 return true;
             case R.id.helpMenu: // Takes user to help blog
                 Intent openHelpBlog = new Intent(Intent.ACTION_VIEW,
-                        Uri.parse("http://chronihelpblog.wordpress.com"));
+                        Uri.parse(getString(R.string.chroni_help_address)));
                 startActivity(openHelpBlog);
                 return true;
             default:

--- a/src/main/java/org/cirdles/chroni/ViewAnalysisImageActivity.java
+++ b/src/main/java/org/cirdles/chroni/ViewAnalysisImageActivity.java
@@ -140,7 +140,7 @@ public class ViewAnalysisImageActivity extends Activity {
                 return true;
             case R.id.helpMenu: // Takes user to help blog
                 Intent openHelpBlog = new Intent(Intent.ACTION_VIEW,
-                        Uri.parse("http://chronihelpblog.wordpress.com"));
+                        Uri.parse(getString(R.string.chroni_help_address)));
                 startActivity(openHelpBlog);
                 return true;
             default:

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -9,5 +9,6 @@
     <string name="about_text">CHRONI is a mobile application developed by the <b>Cyber Infrastructure Research and Development Lab for the Earth Sciences</b>, CIRDLES, at the College of Charleston in Charleston, SC. CIRDLES is creating cyber infrastructure for geochronology in an interdisciplinary collaboration among our software engineers and geochemists from two NSF-supported initiatives, EARTHTIME and EarthChem. Using <b>ET Redux</b>, users can upload and retrieve their data and results to the GeoChron.org data repository. If you are interested in learning more about CIRDLES, please contact Dr. Bowring at <i>bowringj@cofc.edu.</i>\n
 Currently, Joye Nettles, a senior at the College of Charleston has been working with Dr. James Bowring to develop this application. Joye has been working on CHRONI since Fall 2012. If you are interested in contacting her for inquiries about the application, please email her at <i>nettlesjj@g.cofc.edu.</i> \n
 We would like to thank the College of Charleston Department of Computer Science, for providing financial support for CIRDLES. Funding was also provided by grant EAR-0930223 from the National Science Foundation and College of Charleston’s Undergraduate Research and Creative Activities MAYS Program.</string>
+    <string name="chroni_help_address">http://cirdles.org/projects/chroni/</string>
 
 </resources>


### PR DESCRIPTION
The help menu item now points to an address string in the strings.xml file within the resources folder.
This ensures that if the address needs to be changed in the future, only one line will need to be changed.
It also now points to a valid address to the new CIRDLES website to the CHRONI project folder. Once the help tab is created within the CHRONI project folder, the menu item will then be changed to point to that. 
