### PR TITLE
Updated Report Settings Issue

### DIFF
--- a/src/main/java/org/cirdles/chroni/HomeScreenActivity.java
+++ b/src/main/java/org/cirdles/chroni/HomeScreenActivity.java
@@ -201,7 +201,7 @@ public class HomeScreenActivity extends Activity  {
                     URLFileReader downloader = new URLFileReader(
                             HomeScreenActivity.this,
                             "HomeScreen",
-                            "http://cirdles.org/sites/default/files/Downloads/CIRDLESDefaultReportSettings.xml",
+                            "https://raw.githubusercontent.com/CIRDLES/cirdles.github.com/master/assets/Default%20Report%20Settings%20XML/Default%20Report%20Settings.xml",
                             "url");
                     saveInitialLaunch();
                     saveCurrentReportSettings();    // Notes that files have been downloaded and application has been properly initialized
@@ -212,7 +212,7 @@ public class HomeScreenActivity extends Activity  {
                     URLFileReader downloader2 = new URLFileReader(
                             HomeScreenActivity.this,
                             "HomeScreen",
-                            "http://cirdles.org/sites/default/files/Downloads/Default%20Report%20Settings%202.xml",
+                            "https://raw.githubusercontent.com/CIRDLES/cirdles.github.com/master/assets/Default%20Report%20Settings%20XML/Default%20Report%20Settings%202.xml",
                             "url");
                     saveInitialLaunch();
                     saveCurrentReportSettings();    // Notes that files have been downloaded and application has been properly initialized


### PR DESCRIPTION
When the app is launched, the Default Report Settings 2.xml is installing and is able to be used with the app, but the Default Report Settings.xml is evaluating to null. This should be fixed soon in the next commit.
