### PR TITLE
Fixed how the Default Report Settings are downloaded for the first time.

### DIFF
--- a/src/main/java/org/cirdles/chroni/AboutActivity.java
+++ b/src/main/java/org/cirdles/chroni/AboutActivity.java
@@ -85,10 +85,7 @@ public class AboutActivity extends Activity  {
                 openRootDirectory.putExtra("Default_Directory",
                         "Root_Directory");
                 return true;
-            case R.id.aboutScreen: // Takes user to about screen
-                Intent openAboutScreen = new Intent(
-                        "android.intent.action.ABOUT");
-                startActivity(openAboutScreen);
+            case R.id.aboutScreen: // Already on the about screen, so just return true
                 return true;
             case R.id.helpMenu: // Takes user to help blog
                 Intent openHelpBlog = new Intent(Intent.ACTION_VIEW,

--- a/src/main/java/org/cirdles/chroni/HistoryActivity.java
+++ b/src/main/java/org/cirdles/chroni/HistoryActivity.java
@@ -179,10 +179,7 @@ public class HistoryActivity extends Activity {
                         "android.intent.action.USERPROFILE");
                 startActivity(openUserProfile);
                 return true;
-            case R.id.historyMenu: //Takes user to credentials screen
-                Intent openHistoryTable = new Intent(
-                        "android.intent.action.HISTORY");
-                startActivity(openHistoryTable);
+            case R.id.historyMenu: // Already on the history menu, so just return true
                 return true;
             case R.id.viewAliquotsMenu: // Takes user to aliquot menu
                 Intent openAliquotFiles = new Intent(

--- a/src/main/java/org/cirdles/chroni/HomeScreenActivity.java
+++ b/src/main/java/org/cirdles/chroni/HomeScreenActivity.java
@@ -153,77 +153,6 @@ public class HomeScreenActivity extends Activity  {
 
     }
 
-
-    /*
-     * Creates the necessary application directories: CIRDLES, Aliquot and
-     * Report Settings folders
-     */
-    protected void oldCreateDirectories() throws FileNotFoundException {
-        boolean defaultReportSettingsPresent = false; // determines whether the report settings is present or not
-        boolean defaultReportSettings2Present = false; // determines whether the report settings is present or not
-
-        // Establishes the CHRONI folders
-        File chroniDirectory = getDir("CHRONI", Context.MODE_PRIVATE); //Creating an internal directory for CHRONI files
-        File aliquotDirectory = new File(chroniDirectory, "Aliquot");
-        File reportSettingsDirectory = new File(chroniDirectory, "Report Settings");
-        File defaultReportSettingsDirectory = new File(reportSettingsDirectory, "Default Report Settings");
-        File defaultReportSettings2Directory = new File(reportSettingsDirectory, "Default Report Settings 2");
-
-        // Creates the directories if they are not there
-        if (!chroniDirectory.exists()) {
-            chroniDirectory.mkdirs();
-        }
-        if (!aliquotDirectory.exists()) {
-            aliquotDirectory.mkdirs();
-        }
-        if (!reportSettingsDirectory.exists()) {
-            reportSettingsDirectory.mkdirs();
-        }
-
-        // Checks internet connection before downloading files
-        ConnectivityManager connManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo mobileWifi = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-
-        // Checks to see if the default report settings is present
-        File[] files = reportSettingsDirectory.listFiles(); // Lists files in CHRONI directory
-        for (File f : files) {
-            if (f.getName().contentEquals("Default Report Settings.xml")) {
-                defaultReportSettingsPresent = true;
-            }if (f.getName().contentEquals("Default Report Settings 2.xml")) {
-                defaultReportSettings2Present = true;
-            }
-        }
-
-            if (mobileWifi.isConnected()) {
-                // Downloads default report settings 1 if not present
-                if (!defaultReportSettingsPresent) {
-                    // Downloads the default report setting file if absent
-                    URLFileReader downloader = new URLFileReader(
-                            HomeScreenActivity.this,
-                            "HomeScreen",
-                            "https://raw.githubusercontent.com/CIRDLES/cirdles.github.com/master/assets/Default%20Report%20Settings%20XML/Default%20Report%20Settings.xml",
-                            "url");
-                    saveInitialLaunch();
-                    saveCurrentReportSettings();    // Notes that files have been downloaded and application has been properly initialized
-                }
-
-                if (!defaultReportSettings2Present) {
-                    // Downloads the default report setting file if absent
-                    URLFileReader downloader2 = new URLFileReader(
-                            HomeScreenActivity.this,
-                            "HomeScreen",
-                            "https://raw.githubusercontent.com/CIRDLES/cirdles.github.com/master/assets/Default%20Report%20Settings%20XML/Default%20Report%20Settings%202.xml",
-                            "url");
-                    saveInitialLaunch();
-                    saveCurrentReportSettings();    // Notes that files have been downloaded and application has been properly initialized
-                }
-
-            }else {
-                Toast.makeText(HomeScreenActivity.this, "Please connect to your local wifi network to download your Default Report Settings files.", Toast.LENGTH_LONG).show();
-            }
-
-    }
-
     /*
     Stores Current Aliquot
      */
@@ -251,13 +180,11 @@ public class HomeScreenActivity extends Activity  {
     */
     protected void saveCurrentReportSettings() {
         // Establishes the CHRONI folders
-        File chroniDirectory = getDir("CHRONI", Context.MODE_PRIVATE); //Creating an internal directory for CHRONI files
-        File reportSettingsDirectory = new File(chroniDirectory, "Report Settings");
-        File defaultReportSettingsDirectory = new File(reportSettingsDirectory, "Default Report Settings");
+        File reportSettingsDirectory = new File(Environment.getExternalStorageDirectory() + "/CHRONI/Report Settings"); //Creating an internal directory for CHRONI files
 
         SharedPreferences settings = getSharedPreferences(PREF_REPORT_SETTINGS, 0);
         SharedPreferences.Editor editor = settings.edit();
-        editor.putString("Current Report Settings", defaultReportSettingsDirectory.getPath()); // makes the Default Report Settings the current report settings
+        editor.putString("Current Report Settings", reportSettingsDirectory.getPath() + "/Default Report Settings.xml"); // makes the Default Report Settings the current report settings
         editor.apply(); // Committing changes
     }
 

--- a/src/main/java/org/cirdles/chroni/MainMenuActivity.java
+++ b/src/main/java/org/cirdles/chroni/MainMenuActivity.java
@@ -95,9 +95,7 @@ public class MainMenuActivity extends Activity {
     public boolean onOptionsItemSelected(MenuItem item) {
         // Handles menu item selection
         switch (item.getItemId()) {
-            case R.id.returnToMenu: // Takes user to main menu
-                Intent openMainMenu = new Intent("android.intent.action.MAINMENU");
-                startActivity(openMainMenu);
+            case R.id.returnToMenu: // Already on the main menu, so just return true
                 return true;
             case R.id.editProfileMenu: //Takes user to credentials screen
                 Intent openUserProfile = new Intent(

--- a/src/main/java/org/cirdles/chroni/URLFileReader.java
+++ b/src/main/java/org/cirdles/chroni/URLFileReader.java
@@ -96,31 +96,35 @@ public class URLFileReader{
 		if(getFileType().contains("Aliquot")){
 			// If downloading based on IGSN URL, just use IGSN for name
 			if(downloadMethod.contains("igsn")){
-			String[] URL = getFileURL().split("igsn=");
-			name = URL[1];
-			if(name.contains("&username=")){
-				// Makes an additional split to remove the username and password query from the file name
-				String[] url2 = name.split("&username=");
-				name = url2[0]; 
-			}
+				String[] URL = getFileURL().split("igsn=");
+				name = URL[1];
+
+				if(name.contains("&username=")){
+					// Makes an additional split to remove the username and password query from the file name
+					String[] url2 = name.split("&username=");
+					name = url2[0];
+				}
 			}
 			
 			// if downloading based on URL, makes name from ending of URL
 			else if(downloadMethod.contains("url")){
+
 				String[] URL = getFileURL().split("/");
 				name = URL[URL.length-1];
+
 				if (name.contains(".xml")){
 					// Removes the file name ending from XML files
 					String [] newName = name.split(".xml");
 					name = newName[0];
 				}
 			}
+
 		}
 
         if(getClassName().contentEquals("HomeScreen")) {
-            if(fileURL.contentEquals("https://raw.githubusercontent.com/CIRDLES/cirdles.github.com/master/assets/Default%20Report%20Settings%20XML/Defaultt%20Report%20Settings.xml")){
+            if (fileURL.contentEquals("https://raw.githubusercontent.com/CIRDLES/cirdles.github.com/master/assets/Default%20Report%20Settings%20XML/Default%20Report%20Settings.xml")) {
                 name = "Default Report Settings";
-            }else if(fileURL.contentEquals("https://raw.githubusercontent.com/CIRDLES/cirdles.github.com/master/assets/Default%20Report%20Settings%20XML/Default%20Report%20Settings%202.xml")){
+            } else if (fileURL.contentEquals("https://raw.githubusercontent.com/CIRDLES/cirdles.github.com/master/assets/Default%20Report%20Settings%20XML/Default%20Report%20Settings%202.xml")) {
                 name = "Default Report Settings 2";
             }
         }
@@ -175,10 +179,6 @@ public class URLFileReader{
 
 		@Override
 		protected String doInBackground(String... sUrl) {
-//			// Directories needed to place files in accurate locations
-//			File chroniDirectory = classContext.getDir("CHRONI", Context.MODE_PRIVATE); //Creating an internal directory for CHRONI files
-//	    	File aliquotDirectory = new File(chroniDirectory, "Aliquot");
-//	    	File reportSettingsDirectory = new File(chroniDirectory, "Report Settings");
 
 			// take CPU lock to prevent CPU from going off if the user
 			// presses the power button during download
@@ -209,12 +209,13 @@ public class URLFileReader{
 						if(fileLength == 55){ // Cancels if invalid IGSN file (if file has a length of 0.05 KB)
 							AliquotMenuActivity.setInvalidFile(true);	// Sets file as invalid
 							cancel(true);
-						}else{
+
+						} else {
                             downloadedFilePath = Environment.getExternalStorageDirectory() + "/CHRONI/Aliquot/" + fileName + ".xml"; // Stores name of path
                             output = new FileOutputStream(Environment.getExternalStorageDirectory() + "/CHRONI/Aliquot/" + fileName + ".xml");
-//							AliquotMenuActivity.setAbsoluteFilePathOfDownloadedAliquot(Environment.getExternalStorageDirectory() + "/CHRONI/Aliquot/" + fileName + ".xml");
 						}
-					}else if(fileType.contains("Report Settings")){
+
+					} else if (fileType.contains("Report Settings")) {
                         downloadedFilePath = Environment.getExternalStorageDirectory() + "/CHRONI/Report Settings/" + fileName + ".xml";
                         output = new FileOutputStream(Environment.getExternalStorageDirectory() + "/CHRONI/Report Settings/" + fileName + ".xml");
 					}
@@ -261,21 +262,16 @@ public class URLFileReader{
         @Override
 		protected void onPreExecute() {
 			super.onPreExecute();
-//			mProgressDialog.show();
 		}
 
 		@Override
 		protected void onProgressUpdate(Integer... progress) {
 			super.onProgressUpdate(progress);
-			// if we get here, length is known, now set indeterminate to false
-//			mProgressDialog.setIndeterminate(false);
-//			mProgressDialog.setMax(100);
-//			mProgressDialog.setProgress(progress[0]);
 		}
 
 		@Override
 		protected void onPostExecute(String result) {
-            boolean erroneousFile = false;
+            boolean erroneousFile;
             if(String.valueOf(classContext).contains("AliquotMenuActivity")){
                 // Figures out if aliquot file is erroneous
                 erroneousFile = parseAliquotFileForError(downloadedFilePath);

--- a/src/main/java/org/cirdles/chroni/UserProfileActivity.java
+++ b/src/main/java/org/cirdles/chroni/UserProfileActivity.java
@@ -356,10 +356,7 @@ public class UserProfileActivity extends Activity {
                 Intent openMainMenu = new Intent("android.intent.action.MAINMENU");
                 startActivity(openMainMenu);
                 return true;
-            case R.id.editProfileMenu: //Takes user to credentials screen
-                Intent openUserProfile = new Intent(
-                        "android.intent.action.USERPROFILE");
-                startActivity(openUserProfile);
+            case R.id.editProfileMenu: // Already on the profile menu, so just return true
                 return true;
             case R.id.historyMenu: //Takes user to credentials screen
                 Intent openHistoryTable = new Intent(


### PR DESCRIPTION
Now the correct settings (both 1 and 2) are downloaded and stored in the Report Settings directory. When they are initially downloaded the user can also now successfully open up an aliquot file the first time (i.e. the preferences/settings file is correctly setup to point to Default Report Settings 1).

Also changed how the dropdown menu works; if the user chooses to go the same page they are already on, nothing will happen (instead of opening an entirely new Intent).
