### PR TITLE
Various changes to how the aliquot table is both displayed and updated.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,11 +4,11 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
     }
 }
 
-apply plugin: 'android'
+apply plugin: 'com.android.application'
 
 dependencies {
     compile 'com.google.android:support-v4:r7'

--- a/src/main/java/org/cirdles/chroni/AliquotMenuActivity.java
+++ b/src/main/java/org/cirdles/chroni/AliquotMenuActivity.java
@@ -76,17 +76,6 @@ public class AliquotMenuActivity extends Activity {
 
         aliquotSelectedFileText = (EditText) findViewById(R.id.aliquotFileSelectText); // Contains selected aliquot file name
 
-        /*
-        // TOOK OUT. SEE onActivityResult()
-        // Gets selected Aliquot file from FilePickerActivity and places the file name on the file select line
-        if (getIntent().hasExtra("AliquotXMLFileName")) {
-            String selectedAliquotFileName = getIntent().getStringExtra("AliquotXMLFileName"); // Specified file name from file browser
-            String[] selectedAliquotFilePath = selectedAliquotFileName.split("/"); // Splits selected file name into relevant parts
-            String fileName = selectedAliquotFilePath[selectedAliquotFilePath.length - 1]; // Creates displayable file name from split file path
-            aliquotSelectedFileText.setText(fileName); // Sets file name for displaying on aliquot file select line
-        }
-        */
-
         aliquotFileSubmitButton = (Button) findViewById(R.id.aliquotFileSubmitButton);
         //Changes button color back to blue if it is not already
         aliquotFileSubmitButton.setBackgroundColor(getResources().getColor(R.color.button_blue));
@@ -94,20 +83,43 @@ public class AliquotMenuActivity extends Activity {
         aliquotFileSubmitButton.setOnClickListener(new View.OnClickListener() {
             // Submits aliquot file to display activity for parsing and displaying in table
             public void onClick(View v) {
+
                 if (aliquotSelectedFileText.getText().length() != 0) {
-                    // Makes sure there is a file selected
-                    Toast.makeText(AliquotMenuActivity.this, "Opening table...", Toast.LENGTH_LONG).show(); // lets user know table is opening
-                    Intent openDisplayTable = new Intent("android.intent.action.DISPLAY"); // Opens display table
-                    openDisplayTable.putExtra("AliquotXML", getIntent().getStringExtra("AliquotXMLFileName")); // Sends selected aliquot file name for display
 
-                    // Changes button color to indicate it has been opened
-                    aliquotFileSubmitButton.setBackgroundColor(Color.LTGRAY);
-                    aliquotFileSubmitButton.setTextColor(Color.BLACK);
-                    saveCurrentAliquot();
+                    // if coming from a previously created table, change the aliquot
+                    if (getIntent().hasExtra("From_Table")) {
+                        if (getIntent().getStringExtra("From_Table").equals("true")) {
 
-                    startActivity(openDisplayTable); // Starts display activity
+                            Toast.makeText(AliquotMenuActivity.this, "Changing Aliquot...", Toast.LENGTH_LONG).show(); // lets user know table is opening
+                            Intent returnAliquot = new Intent("android.intent.action.DISPLAY");
+                            returnAliquot.putExtra("newAliquot", "true");   // tells if a new aliquot has been chosen
 
-                }else{
+                            // Changes button color to indicate it has been opened
+                            aliquotFileSubmitButton.setBackgroundColor(Color.LTGRAY);
+                            aliquotFileSubmitButton.setTextColor(Color.BLACK);
+                            saveCurrentAliquot();
+
+                            setResult(RESULT_OK, returnAliquot);
+                            finish();
+                        }
+
+                    } else {
+
+                        // Makes sure there is a file selected
+                        Toast.makeText(AliquotMenuActivity.this, "Opening table...", Toast.LENGTH_LONG).show(); // lets user know table is opening
+                        Intent openDisplayTable = new Intent("android.intent.action.DISPLAY"); // Opens display table
+                        openDisplayTable.putExtra("AliquotXML", getIntent().getStringExtra("AliquotXMLFileName")); // Sends selected aliquot file name for display
+
+                        // Changes button color to indicate it has been opened
+                        aliquotFileSubmitButton.setBackgroundColor(Color.LTGRAY);
+                        aliquotFileSubmitButton.setTextColor(Color.BLACK);
+                        saveCurrentAliquot();
+
+                        startActivity(openDisplayTable); // Starts display activity
+                    }
+
+
+                } else {
                     // Tells user to select a file for viewing
                     Toast.makeText(AliquotMenuActivity.this, "Please select an aliquot file to view.", Toast.LENGTH_LONG).show(); // lets user know table is opening
                 }
@@ -156,19 +168,19 @@ public class AliquotMenuActivity extends Activity {
 
 
 
-    /*
-* Stores Current Aliquot
-*/
+    /**
+     * Stores Current Aliquot
+     */
     protected void saveCurrentAliquot() {
         SharedPreferences settings = getSharedPreferences(PREF_ALIQUOT, 0);
         SharedPreferences.Editor editor = settings.edit();
         editor.putString("Current Aliquot", getIntent().getStringExtra("AliquotXMLFileName")); // gets chosen file from file browser and stores
-        editor.commit(); // Commiting changes
+        editor.apply(); // Committing changes
     }
 
 
-    /*
-    Requests file name from user and proceeds to download based on input
+    /**
+     * Requests file name from user and proceeds to download based on input
      */
 //        public void requestFileName(){
 //
@@ -207,7 +219,7 @@ public class AliquotMenuActivity extends Activity {
 //                userFileNameAlert.show();
 //            }
 
-    /*
+    /**
 	 * Creates file name based on the file's type and URL
 	 */
     protected String createFileName(String downloadMethod, String fileUrl) {
@@ -227,7 +239,6 @@ public class AliquotMenuActivity extends Activity {
     }
 
     @Override
-    // TODO Not sure what this function is doing right now. Figure out!  - CHECK
     // Gets the Extra that FilePicker returns and puts it in This Intent's Extra
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == 1) {
@@ -240,13 +251,10 @@ public class AliquotMenuActivity extends Activity {
                     aliquotSelectedFileText.setText(fileName); // Sets file name for displaying on aliquot file select line
                 }
             }
-            else if (resultCode == RESULT_CANCELED) {
-                return;
-            }
         }
     }
 
-    /*
+    /**
      * Retrieves the currently stored username and password
      * If none present, returns None
      */
@@ -256,10 +264,10 @@ public class AliquotMenuActivity extends Activity {
         setGeochronPassword(settings.getString("Geochron Password", "None"));
     }
 
-    /*
+    /**
      * Creates URL from the constant GeoChron URL and IGSN
      */
-    public final static String makeURI(String baseURL, String IGSN) {
+    public static String makeURI(String baseURL, String IGSN) {
         String URI = baseURL + IGSN;
         if (!getGeochronUsername().contentEquals("None")&& !getGeochronPassword().contentEquals("None")) {
             URI += "&username="+ getGeochronUsername()+"&password="+ getGeochronPassword(); 	// Create unique URL and password if credentials stored
@@ -271,16 +279,16 @@ public class AliquotMenuActivity extends Activity {
         return geochronUsername;
     }
 
-    public void setGeochronUsername(String geochronUsername) {
-        this.geochronUsername = geochronUsername;
+    public void setGeochronUsername(String geochronUser) {
+        geochronUsername = geochronUser;
     }
 
     public static String getGeochronPassword() {
         return geochronPassword;
     }
 
-    public void setGeochronPassword(String geochronPassword) {
-        this.geochronPassword = geochronPassword;
+    public void setGeochronPassword(String geochronPass) {
+        geochronPassword = geochronPass;
     }
 
     public String getAbsoluteFilePathOfDownloadedAliquot() {
@@ -288,7 +296,7 @@ public class AliquotMenuActivity extends Activity {
     }
 
     public void setAbsoluteFilePathOfDownloadedAliquot(String absoluteFileName) {
-        this.absoluteFilePathOfDownloadedAliquot = absoluteFileName;
+        absoluteFilePathOfDownloadedAliquot = absoluteFileName;
     }
 
     @Override

--- a/src/main/java/org/cirdles/chroni/ReportSettingsMenuActivity.java
+++ b/src/main/java/org/cirdles/chroni/ReportSettingsMenuActivity.java
@@ -83,15 +83,34 @@ public class ReportSettingsMenuActivity extends Activity {
         reportSettingsApplyButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 if (reportSettingsSelectedFileText.getText().length() != 0) {
-                    Intent openDisplayTable = new Intent(
-                            "android.intent.action.DISPLAY");
-                    openDisplayTable.putExtra("ReportSettingsXML", getIntent().getStringExtra("ReportSettingsXMLFileName")); // Sends selected report settings file to display activity
 
-                    // Changes button color to indicate it has been opened
-                    reportSettingsApplyButton.setBackgroundColor(Color.LTGRAY);
-                    reportSettingsApplyButton.setTextColor(Color.BLACK);
-                    saveCurrentReportSettings();
-                    startActivity(openDisplayTable);
+                    if (getIntent().hasExtra("From_Table")) {
+                        if (getIntent().getStringExtra("From_Table").equals("true")) {
+
+                            Toast.makeText(ReportSettingsMenuActivity.this, "Changing Report Settings...", Toast.LENGTH_LONG).show();
+                            Intent returnReportSettings = new Intent("android.intent.action.DISPLAY");
+                            returnReportSettings.putExtra("newReportSettings", "true"); // tells if new report settings have been chosen
+
+                            // Changes button color to indicate it has been opened
+                            reportSettingsApplyButton.setBackgroundColor(Color.LTGRAY);
+                            reportSettingsApplyButton.setTextColor(Color.BLACK);
+                            saveCurrentReportSettings();
+
+                            setResult(RESULT_OK, returnReportSettings);
+                            finish();
+                        }
+
+                    } else {
+
+                        Intent openDisplayTable = new Intent("android.intent.action.DISPLAY");
+                        openDisplayTable.putExtra("ReportSettingsXML", getIntent().getStringExtra("ReportSettingsXMLFileName")); // Sends selected report settings file to display activity
+
+                        // Changes button color to indicate it has been opened
+                        reportSettingsApplyButton.setBackgroundColor(Color.LTGRAY);
+                        reportSettingsApplyButton.setTextColor(Color.BLACK);
+                        saveCurrentReportSettings();
+                        startActivity(openDisplayTable);
+                    }
                 }
             }
         });
@@ -100,18 +119,14 @@ public class ReportSettingsMenuActivity extends Activity {
         Button reportSettingsCancelButton = (Button) findViewById(R.id.reportSettingsMenuCancelButton);
         reportSettingsCancelButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
-                    Intent openDisplayTable = new Intent(
-                            "android.intent.action.DISPLAY");
-                    openDisplayTable.putExtra("ReportSettingsXML", getIntent().getStringExtra("ReportSettingsXMLFileName")); // Sends selected report settings file to display activity
-                    saveCurrentReportSettings();
-                    startActivity(openDisplayTable);
+                    finish();
             }
         });
     }
 
-    /*
-Requests file name from user and  proceeds to download based on input
- */
+    /**
+     * Requests file name from user and  proceeds to download based on input
+     */
     public void requestFileName(){
         AlertDialog.Builder userFileNameAlert = new AlertDialog.Builder(ReportSettingsMenuActivity.this);
 
@@ -165,11 +180,11 @@ Requests file name from user and  proceeds to download based on input
         }
     }
 
-    /*
+    /**
 	 * Creates file name based on the file's type and URL
 	 */
     protected String createFileName(String downloadMethod, String fileUrl) {
-        String name = null;
+        String name;
         //makes name from ending of URL
         String[] URL = fileUrl.split("/");
         name = URL[URL.length-1];
@@ -189,26 +204,25 @@ Requests file name from user and  proceeds to download based on input
         this.absoluteFilePath = absoluteFilePath;
     }
 
-    /*
-Splits report settings file name returning a displayable version without the entire path
- */
+    /**
+     * Splits report settings file name returning a displayable version without the entire path
+     */
     private String splitReportSettingsName(String fileName){
         String[] fileNameParts = fileName.split("/");
-        String reportSettingsName = fileNameParts[fileNameParts.length-1];
-        return reportSettingsName;
+        return fileNameParts[fileNameParts.length-1];
     }
 
-    /*
-    * Accesses current report settings file
-    */
+    /**
+     * Accesses current report settings file
+     */
     private String retrieveReportSettingsFileName() {
         SharedPreferences settings = getSharedPreferences(PREF_REPORT_SETTINGS, 0);
         return settings.getString("Current Report Settings", "Default Report Settings.xml"); // Gets current RS and if no file there, returns default as the current file
     }
 
-    /*
-    * Stores Current Report Settings
-    */
+    /**
+     * Stores Current Report Settings
+     */
     protected void saveCurrentReportSettings() {
         SharedPreferences settings = getSharedPreferences(PREF_REPORT_SETTINGS, 0);
         SharedPreferences.Editor editor = settings.edit();

--- a/src/main/java/org/cirdles/chroni/UserProfileActivity.java
+++ b/src/main/java/org/cirdles/chroni/UserProfileActivity.java
@@ -13,7 +13,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.http.Header;
-import org.apache.http.client.HttpResponseException;
 import org.xml.sax.SAXException;
 
 import com.loopj.android.http.AsyncHttpResponseHandler;
@@ -29,7 +28,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -106,7 +104,7 @@ public class UserProfileActivity extends Activity {
                         try {
                             // validates credentials if not empty
                             validateGeochronCredentials(getGeochronUsername(), getGeochronPassword());
-                        } catch (HttpResponseException e) {
+                        } catch (Exception e) {
                             e.printStackTrace();
                             Toast.makeText(UserProfileActivity.this, "Connection error", Toast.LENGTH_LONG).show();
                         }
@@ -181,7 +179,7 @@ public class UserProfileActivity extends Activity {
     * @param password
     * @return
     */
-	public void validateGeochronCredentials(String username, String password) throws HttpResponseException {
+	public void validateGeochronCredentials(String username, String password) {
 	    boolean isValid = false; // Geochron Credential boolean
 		String geochronCredentialsService = "http://www.geochronportal.org/credentials_service.php";
 

--- a/src/main/res/layout/display.xml
+++ b/src/main/res/layout/display.xml
@@ -8,32 +8,59 @@
 
     <TableRow
         android:id="@+id/labelRow"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center">
+
+        <Button android:id="@+id/reportSettingsTableButton"
+            android:textSize="15sp" android:textColor="#000000"
+            android:typeface="normal" android:padding="25dp"
+            android:textStyle="bold"/>
+
+        <Button android:id="@+id/aliquotTableButton"
+            android:textSize="15sp" android:textColor="#000000"
+            android:typeface="normal" android:padding="25dp"
+            android:textStyle="bold"/>
+
+    </TableRow>
 
     <TableRow
         android:id="@+id/buttonRow"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" >
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center">
+
+        <Button android:id="@+id/concordiaTableButton"
+            android:visibility="gone"
+            android:textColor="#000000" android:textSize="13sp"
+            android:text="Concordia" android:typeface="normal"
+            android:padding="15dp" android:gravity="center"
+            android:textStyle="bold"/>
+
+        <Button android:id="@+id/probabilityDensityTableButton"
+            android:visibility="gone"
+            android:textColor="#000000" android:textSize="13sp"
+            android:text="Probability Density" android:typeface="normal"
+            android:padding="15dp" android:gravity="center"
+            android:textStyle="bold"/>
+
     </TableRow>
     
     <HorizontalScrollView
         android:id="@+id/horizontalScrollView"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_below="@+id/viewConcordiaButton" >
+        android:layout_height="wrap_content" >
 
         <LinearLayout
             android:id="@+id/displayTableLayout"
-            android:layout_width="fill_parent"
+            android:layout_width="wrap_content"
             android:layout_height="fill_parent"
             android:orientation="vertical" >
 
             <TableLayout
+                android:id="@+id/categoryNameTable"
                 android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:id="@+id/categoryNameTable"></TableLayout>
+                android:layout_height="fill_parent" />
 
             <TableLayout
                 android:id="@+id/tableForHeader"
@@ -51,8 +78,11 @@
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content" >
                 </TableLayout>
+
             </ScrollView>
+
         </LinearLayout>
+
     </HorizontalScrollView>
 
 </LinearLayout>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -13,5 +13,8 @@ We would like to thank the College of Charleston Department of Computer Science,
     <string name="chroni_aliquot_help_address">http://cirdles.org/projects/chroni/#aliquotHelp</string>
     <string name="chroni_report_settings_help_address">http://cirdles.org/projects/chroni/#reportSettingsHelp</string>
 
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
+
 
 </resources>


### PR DESCRIPTION
When the table is first created, both the tableLayouts and the data array are stored so that when the
screen is rotated it simply updates the view, allowing for faster rotation.

Also, instead of opening a completely new table when either of the Report Settings or Aliquot buttons
is clicked, the user is now brought back to the same table with the updated information once they have
specified their changes.

A bug in the category header spacing that was not previously found has also been fixed.
